### PR TITLE
Using sane defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 mailman3_domain: example.com
-mailman3_service_name: "www.{{ mailman3_domain }}"
+mailman3_server_name: "mailman.{{ mailman3_domain }}"
 mailman3_service_desc: Example List Server
 mailman3_locale: en
-mailman3_mail: "changeme@{{ mailman3_domain }}"
+mailman3_mail: "mailman-admin@{{ mailman3_domain }}"
 mailman3_tz: UTC
 mailman3_update_translations: false
 
@@ -48,7 +48,7 @@ mailman3_postfix_debconf:
   - name: postfix
     question: postfix/mailname
     vtype: string
-    value: "{{ mailman3_service_name }}"
+    value: "{{ mailman3_server_name }}"
   - name: postfix
     question: postfix/main_mailer_type
     vtype: select
@@ -59,7 +59,7 @@ mailman3_postfix_main_cfg:
   unknown_local_recipient_reject_code: "550"
   owner_request_special: "no"
   transport_maps: hash:/var/lib/mailman3/data/postfix_lmtp
-  local_recipient_maps: hash:/var/lib/mailman3/data/postfix_lmtp
+  local_recipient_maps: hash:/var/lib/mailman3/data/postfix_lmtp $alias_maps
   relay_domains: hash:/var/lib/mailman3/data/postfix_domains
 
 # postgres
@@ -105,7 +105,9 @@ mailman3_web_template: true
 mailman3_web_template_src: mailman-web.py.j2
 mailman3_web_template_dest: /etc/mailman3/mailman-web.py
 mailman3_web_admin_name: Mailman Suite Admin
-mailman3_web_admin_mail: root@localhost
+mailman3_web_admin_mail: '{{ mailman3_mail }}'
+mailman3_web_from_email: 'postorius@{{ mailman3_server_name }}'
+mailman3_web_server_email: 'root@{{ mailman3_server_name }}'
 mailman3_web_language_code: en-us
 mailman3_web_domain: localhost.local
 mailman3_web_base_url: http://localhost/
@@ -114,7 +116,7 @@ mailman3_web_apps:
   - 'postorius'
   - 'django_mailman3'
   # Uncomment the next line to enable the admin:
-  # - 'django.contrib.admin'
+  - 'django.contrib.admin'
   # Uncomment the next line to enable admin documentation:
   # - 'django.contrib.admindocs'
   - 'django.contrib.auth'
@@ -132,7 +134,7 @@ mailman3_web_apps:
   - 'allauth'
   - 'allauth.account'
   - 'allauth.socialaccount'
-  - 'django_mailman3.lib.auth.fedora'
+  # - 'django_mailman3.lib.auth.fedora'
   # - 'allauth.socialaccount.providers.openid'
   # - 'allauth.socialaccount.providers.github'
   # - 'allauth.socialaccount.providers.gitlab'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ mailman3_nginx_status_template_dest: /etc/nginx/sites-enabled/status.conf
 
 # postfix
 mailman3_install_postfix: true
+mailman3_configure_postfix: '{{ mailman3_install_postfix | bool }}'
 mailman3_postfix_debconf:
   - name: postfix
     question: postfix/mailname

--- a/tasks/certbot.yml
+++ b/tasks/certbot.yml
@@ -15,7 +15,7 @@
   - when:
       - certbot_install is changed
       - certbot_certificates.stdout is defined
-      - mailman3_service_name not in certbot_certificates.stdout
+      - mailman3_server_name not in certbot_certificates.stdout
     block:
       - name: temporarly reconfigure nginx for self sign
         when: mailman3_nginx_template
@@ -31,7 +31,7 @@
 
       - name: install certificate
         shell: "certbot -n --nginx{{ ' --test-cert ' if certbot_install_test is
-          defined else ' ' }}-d {{ mailman3_service_name }} --agree-tos
+          defined else ' ' }}-d {{ mailman3_server_name }} --agree-tos
           -m '{{ mailman3_install_certbot_mail }}'"
         notify: reload nginx
 

--- a/tasks/debconf.yml
+++ b/tasks/debconf.yml
@@ -25,7 +25,7 @@
   vars:
     this_no_log: "{{ true if item.vtype == 'password' else false }}"
   no_log: "{{ this_no_log }}"
-  changed_when: (mailman3_postfix_debconf_status.changed if not this_no_log else false)
+  changed_when: (mailman3_debconf_status.changed if not this_no_log else false)
   register: mailman3_debconf_status
   debconf:
     name: "{{ item.name }}"

--- a/tasks/mailman3.yml
+++ b/tasks/mailman3.yml
@@ -85,6 +85,9 @@
         state: absent
 
 - name: mailman cfg
+  vars:
+    this_no_log: "{{ true if item.key.endswith('_pass') else false }}"
+  no_log: "{{ this_no_log }}"
   when: mailman3_cfg is defined and mailman3_cfg
   loop: "{{ mailman3_cfg | ini_dict_flatten }}"
   cfg_file:
@@ -99,6 +102,9 @@
   notify: reload mailman
 
 - name: mailman hyperkitty cfg
+  vars:
+    this_no_log: "{{ true if item.key.endswith('_key') else false }}"
+  no_log: "{{ this_no_log }}"
   when: mailman3_hyperkitty_cfg is defined and mailman3_hyperkitty_cfg
   loop: "{{ mailman3_hyperkitty_cfg | ini_dict_flatten }}"
   cfg_file:

--- a/tasks/postfix.yml
+++ b/tasks/postfix.yml
@@ -1,4 +1,4 @@
-- when: mailman3_install_postfix
+- when: mailman3_configure_postfix
   block:
     - name: install postfix
       apt:

--- a/templates/mailman-web.py.j2
+++ b/templates/mailman-web.py.j2
@@ -49,6 +49,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         #'ENGINE': 'django.db.backends.mysql',
         # DB name or path to database file if using sqlite3.
+        #'NAME': '/var/lib/mailman3/web/mailman3web.db',
         'NAME': 'mailman3web',
         # The following settings are not used with sqlite3:
         'USER': 'mailman3web',
@@ -113,14 +114,16 @@ EMAILNAME = '{{ mailman3_web_domain }}'
 # otherwise the emails may get rejected.
 # https://docs.djangoproject.com/en/1.8/ref/settings/#default-from-email
 # DEFAULT_FROM_EMAIL = "mailing-lists@you-domain.org"
-DEFAULT_FROM_EMAIL = 'postorius@{}'.format(EMAILNAME)
+# DEFAULT_FROM_EMAIL = 'postorius@{}'.format(EMAILNAME)
+DEFAULT_FROM_EMAIL = '{{ mailman3_web_from_email }}'
 
 # If you enable email reporting for error messages, this is where those emails
 # will appear to be coming from. Make sure you set a valid domain name,
 # otherwise the emails may get rejected.
 # https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-SERVER_EMAIL
 # SERVER_EMAIL = 'root@your-domain.org'
-SERVER_EMAIL = 'root@{}'.format(EMAILNAME)
+# SERVER_EMAIL = 'root@{}'.format(EMAILNAME)
+SERVER_EMAIL = '{{ mailman3_web_server_email }}'
 
 
 # Django Allauth

--- a/templates/mailman3.conf.j2
+++ b/templates/mailman3.conf.j2
@@ -29,8 +29,8 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/{{ mailman3_server_name }}/privkey.pem;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 {% endif %}
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 5m;
     client_max_body_size {{ mailman3_nginx_client_max_body_size }};

--- a/templates/mailman3.conf.j2
+++ b/templates/mailman3.conf.j2
@@ -8,26 +8,25 @@ upstream mailman {
 server {
     listen 80;
     listen [::]:80;
-    server_name {{ mailman3_service_name }};
+    server_name {{ mailman3_server_name }};
     return 301 https://$server_name$request_uri;
 
     access_log  /var/log/nginx/mailman_access.log  combined;
     error_log /var/log/nginx/mailman_error.log warn;
-
 }
 {% if mailman3_nginx_ssl is defined and mailman3_nginx_ssl %}
 server {
     listen 443 ssl {{ mailman3_nginx_ssl_options }};
     listen [::]:443 ssl {{ mailman3_nginx_ssl_options }};
-    server_name {{ mailman3_service_name }};
+    server_name {{ mailman3_server_name }};
     server_tokens off;
 {% if mailman3_nginx_self_crt %}
     ssl_certificate /etc/ssl/certs/ssl-cert-snakeoil.pem;
     ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
     ssl_dhparam /etc/nginx/dhparam.pem;
 {% else %}
-    ssl_certificate /etc/letsencrypt/live/{{ mailman3_service_name }}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/{{ mailman3_service_name }}/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/{{ mailman3_server_name }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ mailman3_server_name }}/privkey.pem;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 {% endif %}
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
@jobcespedes What a wonderful Ansible role with great code quality! Thanks a lot. It helped me a lot getting Mailman 3 up and running.

I struggled a bit with your defaults, especially since it was hard to change the default mailman-web (Postorius) admin user's email `root@localhost` afterwards, if that was forgotten to getting overwritten on deploy.

Here's my changes:

- Renamed `mailman3_service_name` var to `mailman3_server_name` which makes more sense
- Bugfix: renamed `mailman3_postfix_debconf_status` to `mailman3_debconf_status`
- Using `mailman-admin@YOURDOMAIN` instead of `changeme@YOURDOMAIN`, since most tutorials recommend that
- Adding `$alias_maps` to Postfix `local_recipient_maps`, so that we could use an alias e.g. for `postorius mailman-admin@YOURDOMAIN`
- mailman-web: make `DEFAULT_FROM_EMAIL` and `SERVER_EMAIL` configurable
- mailman-web: enable `django.contrib.admin` in `INSTALLED_APPS` by default, as a Mailman 3 install without admin probably doesn't make much sense (and in my case errored out)
- mailman-web: disabled socialaccounts by also disabling `django_mailman3.lib.auth.fedora` (which probably nobody ever wants)
- introduce new `mailman3_configure_postfix` var to be able to only configure Postfix without installing it (for those who already use their own role to install Postfix)

Hope you can merge this. It was tested on a fresh Debian Bullseye 11.5 install.

Cheers, Philip